### PR TITLE
Moved PlaytimeLayer open button to StatsLayer

### DIFF
--- a/.github/workflows/multi-platform.yml
+++ b/.github/workflows/multi-platform.yml
@@ -18,6 +18,10 @@ jobs:
         - name: macOS
           os: macos-latest
 
+        - name: iOS
+          os: macos-latest
+          target: iOS
+
         - name: Android32
           os: ubuntu-latest
           target: Android32
@@ -35,6 +39,7 @@ jobs:
       - name: Build the mod
         uses: geode-sdk/build-geode-mod@main
         with:
+          sdk: nightly
           combine: true
           target: ${{ matrix.config.target }}
 

--- a/about.md
+++ b/about.md
@@ -1,6 +1,8 @@
 # Playtime
 View your <cy>playtime</c> directly <cl>in-game</c>!
 
+Watch for <cl>open</c> button <cy>in stats</c> dropdown.
+
 This counts your <cl>in-game time</c> and <co>editor time</c>.
 
 Thank you to <cy>Zilko</c> for helping me make this <co>mod</c> :3

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+# 1.0.2
+- Moved PlaytimeLayer open button to StatsLayer (by [user95401](https://geode-sdk.org/developers/127))
 # 1.0.1
 - Fixed the editor playtime for macOS (thank you <cy>hiimjasmine00</c>!)
 # 1.0.0

--- a/mod.json
+++ b/mod.json
@@ -8,7 +8,7 @@
 	},
 	"id": "flingus.playtime",
 	"name": "Playtime!",
-	"version": "v1.0.1",
+	"version": "v1.0.2",
 	"developer": "flingus",
 	"description": "Shows how much you played the game.",
 	"links": {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,27 +3,37 @@
 
 using namespace geode::prelude;
 
-#include <Geode/modify/MenuLayer.hpp>
+#include <Geode/modify/StatsLayer.hpp>
 
-class $modify(MyMenuLayer, MenuLayer) {
-	bool init() {
-		if (!MenuLayer::init()) {
-			return false;
+class $modify(StatsLayerExt, StatsLayer) {
+	virtual void customSetup() {
+		StatsLayer::customSetup();
+
+		auto playtime = CCMenuItemExt::createSpriteExtraWithFrameName(
+			"GJ_timeIcon_001.png", 1.25f, [](CCMenuItem*) {
+				PlaytimeLayer::create()->show();
+			}
+		);
+		playtime->setID("playtime-button"_spr);
+
+		if (auto menu = this->m_buttonMenu) { //paranoic test
+			auto back = menu->getChildByType(0);
+			if (!back) return;
+			//add btn
+			menu->addChild(playtime);
+			//set layout if there is no one already
+			if (not menu->getLayout()) {
+				//fix point up to aaa... back btn?
+				menu->setPositionY(menu->getPositionY() + (back->getContentHeight() / 2));
+				menu->setAnchorPoint(CCPointMake(0.5f, 1.f));
+				menu->setLayout(
+					ColumnLayout::create()
+					->setAxisAlignment(AxisAlignment::End)
+					->setAxisReverse(true)
+				);
+			}
+			else menu->updateLayout();
+
 		}
-
-		auto myButton = CCMenuItemSpriteExtra::create(CircleButtonSprite::createWithSpriteFrameName("GJ_timeIcon_001.png", 0.85f, CircleBaseColor::Green, CircleBaseSize::MediumAlt), this, menu_selector(MyMenuLayer::onPlaytime));
-
-		auto menu = this->getChildByID("bottom-menu");
-		menu->addChild(myButton);
-
-		myButton->setID("playtime-button"_spr);
-
-		menu->updateLayout();
-
-		return true;
-	}
-
-	void onPlaytime(CCObject*) {
-		PlaytimeLayer::create()->show();
 	}
 };


### PR DESCRIPTION
poor bottom menu at MenuLayer... I think its better to put open button to stats layer :>
![image](https://github.com/user-attachments/assets/9553a858-8cc8-411e-a362-686f7618d8f9)